### PR TITLE
Only test base model on Pi

### DIFF
--- a/.github/workflows/pi.yml
+++ b/.github/workflows/pi.yml
@@ -14,4 +14,4 @@ jobs:
         commands: |
             sudo apt install -y python3 python3-pip
             pip3 install -r requirements.txt
-            make test
+            make test-base

--- a/makefile
+++ b/makefile
@@ -1,9 +1,11 @@
 all: lint test
 
-.PHONY: test lint format spellcheck upload clean
+.PHONY: test test-base lint format spellcheck upload clean
 
-test:
+test-base:
 	python3 -m doctest -o ELLIPSIS -o NORMALIZE_WHITESPACE languagemodels/*.py
+
+test: test-base
 	env LANGUAGEMODELS_SIZE=large python3 -m doctest -o ELLIPSIS -o NORMALIZE_WHITESPACE languagemodels/*.py
 	env LANGUAGEMODELS_SIZE=xl python3 -m doctest -o ELLIPSIS -o NORMALIZE_WHITESPACE languagemodels/*.py
 


### PR DESCRIPTION
Prior to this change, large and xl models were being tested on every platform. This is slow on the Pi platform due to emulation. This change will only test the base model on the Pi.