### PR TITLE
Add support for gte-small embeddings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.0
+
+### Added
+
+- Add support for gte-small embeddings
+
 ## 0.8.0
 
 ### Changed

--- a/languagemodels/config.py
+++ b/languagemodels/config.py
@@ -174,6 +174,15 @@ models = [
         "license": "apache-2.0",
     },
     {
+        "name": "gte-small",
+        "tuning": "embedding",
+        "params": 33e6,
+        "quantization": "int8",
+        "backend": "ct2",
+        "architecture": "encoder-only-transformer",
+        "license": "mit",
+    },
+    {
         "name": "e5-small-v2",
         "tuning": "embedding",
         "params": 33e6,


### PR DESCRIPTION
This change adds support for [gte-small](https://huggingface.co/thenlper/gte-small) embeddings. This model performs well for its size on the MTEB leaderboard and supports both natural language and code embeddings.