### PR TITLE
fix : Add the name of the document when you add it to the context

### DIFF
--- a/languagemodels/embeddings.py
+++ b/languagemodels/embeddings.py
@@ -325,7 +325,7 @@ class RetrievalContext:
         """
 
         if doc not in self.docs:
-            self.docs.append(Document(doc,name=name))
+            self.docs.append(Document(doc, name=name))
             self.store_chunks(doc, name)
 
     def store_chunks(self, doc, name=""):


### PR DESCRIPTION
It's a little fix, the code is now adding the document name into the context