### PR TITLE
Guardrails for prompt length

### DIFF
--- a/languagemodels/config.py
+++ b/languagemodels/config.py
@@ -959,6 +959,7 @@ Config.schema = {
     "instruct_model": ConfigItem(Config.validate_model, "LaMini-Flan-T5-248M"),
     "embedding_model": ConfigItem(Config.validate_model, "all-MiniLM-L6-v2"),
     "code_model": ConfigItem(Config.validate_model, "codet5p-220m-py"),
+    "max_prompt_length": ConfigItem(int, 50_000),
 }
 
 config = Config()

--- a/languagemodels/embeddings.py
+++ b/languagemodels/embeddings.py
@@ -325,7 +325,7 @@ class RetrievalContext:
         """
 
         if doc not in self.docs:
-            self.docs.append(Document(doc,name=name))
+            self.docs.append(Document(doc, name=name))
             self.store_chunks(doc, name)
 
     def store_chunks(self, doc, name=""):

--- a/languagemodels/embeddings.py
+++ b/languagemodels/embeddings.py
@@ -325,7 +325,7 @@ class RetrievalContext:
         """
 
         if doc not in self.docs:
-            self.docs.append(Document(doc))
+            self.docs.append(Document(doc,name=name))
             self.store_chunks(doc, name)
 
     def store_chunks(self, doc, name=""):

--- a/languagemodels/inference.py
+++ b/languagemodels/inference.py
@@ -18,7 +18,8 @@ def truncate_prompt(prompt):
     max_prompt_length = config["max_prompt_length"]
     if len(prompt) > max_prompt_length:
         print(
-            f"Warning: Prompt truncated from {len(prompt)} to {max_prompt_length} characters to avoid OOM."
+            f"Warning: Prompt truncated from {len(prompt)} to "
+            f"{max_prompt_length} characters to avoid OOM."
         )
         return prompt[:max_prompt_length]
     return prompt

--- a/languagemodels/inference.py
+++ b/languagemodels/inference.py
@@ -13,6 +13,17 @@ class InferenceException(Exception):
     pass
 
 
+def truncate_prompt(prompt):
+    """Truncates a prompt to the maximum length allowed by the config"""
+    max_prompt_length = config["max_prompt_length"]
+    if len(prompt) > max_prompt_length:
+        print(
+            f"Warning: Prompt truncated from {len(prompt)} to {max_prompt_length} characters to avoid OOM."
+        )
+        return prompt[:max_prompt_length]
+    return prompt
+
+
 def list_tokens(prompt):
     """Generates a list of tokens for a supplied prompt
 
@@ -22,6 +33,7 @@ def list_tokens(prompt):
     >>> list_tokens("Hello, world!")
     [('...Hello', ...), ... ('...world', ...), ...]
     """
+    prompt = truncate_prompt(prompt)
     tokenizer, _ = get_model("instruct")
 
     output = tokenizer.encode(prompt, add_special_tokens=False)
@@ -187,7 +199,9 @@ def generate(
         repetition_penalty = model_info.get("repetition_penalty", 1.3)
 
     prompts = [fmt.replace("{instruction}", inst) for inst in instructions]
-    prompts_tok = [tokenizer.encode(p).tokens for p in prompts]
+    truncated_prompts = [truncate_prompt(p) for p in prompts]
+
+    prompts_tok = [tokenizer.encode(p).tokens for p in truncated_prompts]
 
     outputs_ids = []
     if hasattr(model, "translate_batch"):
@@ -283,6 +297,7 @@ def rank_instruct(inputs, targets):
     model_info = get_model_info("instruct")
     fmt = model_info.get("prompt_fmt", "{instruction}")
     inputs = [fmt.replace("{instruction}", inst) for inst in inputs]
+    inputs = [truncate_prompt(i) for i in inputs]
 
     targ_tok = [tokenizer.encode(t, add_special_tokens=False).tokens for t in targets]
     targ_tok *= len(inputs)


### PR DESCRIPTION
I’ve added a new max_prompt_length parameter in the config. It’s set by default to 50000, which allows most users to work without running into memory issues. Advanced users can still increase this limit if they need to handle very long prompts explicitly.

After some investigation, I identified the issue in inference.py, specifically at this line:

`prompts_tok = [tokenizer.encode(p).tokens for p in prompts]`

While the tokenizer does cap the output to a model-specific token limit (e.g., 512 for some models), it still processes the entire prompt. So if a prompt is very long, the processing time and memory usage can spike unnecessarily.

To address this, I added a function that truncates the prompts according to the max_prompt_length parameter before tokenization.

---

Feel free to improve this pull request and give me your feedback, especially regarding documentation, the way I have implemented this or anything else I may have missed. I'm still learning, so any feedback or contributions are welcome 🙏🏼

